### PR TITLE
Command line interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,22 +3,31 @@
 [![Build Status](https://travis-ci.org/AcademicTorrents/at-python.svg?branch=master)](https://travis-ci.org/AcademicTorrents/at-python)
 [![codecov](https://codecov.io/gh/AcademicTorrents/at-python/branch/master/graph/badge.svg)](https://codecov.io/gh/AcademicTorrents/at-python)
 
-This repository is an implementation of the BitTorrent protocol written in Python and downloadable as a `pip` module. You can download datasets from AcademicTorrents.com in two lines of code:
-```
+This repository is an implementation of the BitTorrent protocol written in Python and downloadable as a `pip` module. You can download datasets from AcademicTorrents.com in two lines of code in any Python script:
+```python
 import academictorrents as at
 path_of_giant_dataset = at.get("323a0048d87ca79b68f12a6350a57776b6a3b7fb") # Download mnist dataset
 ```
 
-# For people who want to download datasets
-we are compatible with Python versions: 2.7, 3.4, 3.5, 3.6
+You can also use the `at-get` command to download datasets directly from your terminal:
+
+```bash
+at-get 323a0048d87ca79b68f12a6350a57776b6a3b7fb -o ~/Downloads
+```
+
+## For people who want to download datasets
+
+We are compatible with Python versions: 2.7, 3.4, 3.5, 3.6.
 
 To install:
 `pip install academictorrents`
 
 This package works with the academictorrents tracker. You can add a hash from [academictorrents.com](academictorrents.com) for your torrent, and download datasets into your project.
 
+### Python example
+
 Here is a little example (it is implemented in `examples/basic_test.py` in case you want to play with our source code):
-```
+```python
 # Import the library
 import academictorrents as at
 
@@ -34,12 +43,31 @@ train_set, valid_set, test_set = pickle.load(mnist, encoding='latin1')
 mnist.close()
 ```
 
+### Command line options
 
-# For Contributors to the AcademicTorrents Python client
-## Introduction
+Run `at-get --help` in the environment where `academictorrents` is installed to get more information about the CLI:
+
+```bash
+usage: at-get [-h] [-o DATASTORE] [-v] hash
+
+Academic Torrents simple command line tool
+
+positional arguments:
+  hash                  Hash of the torrent to download
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -o DATASTORE, --datastore DATASTORE
+                        Location where to place the files
+  -v, --verbose         Show logs
+
+```
+
+## For Contributors to the AcademicTorrents Python client
+### Introduction
 We use Github issues and pull requests to manage development of this repository. The following is a guide for setting up the codebase to contribute PRs or try to debug issues.
 
-## Installation
+### Installation
 Getting setup to work on this client is pretty easy. First, install the source code, then install the dependencies with `pip`:
 
 ```
@@ -49,10 +77,10 @@ pip install -r requirements.txt
 ```
 Done!
 
-## Testing
+### Testing
 We have a test suite that you can run with `pytest -s tests/`. These tests also run on travis after every push to github. Some of our tests are empty -- usually in parts of the codebase that have been changing quickly -- but we should continue increasing our coverage. If you want to just run one little download, use `python examples/basic_test.py` (example code above).
 
-## Architecture
+### Architecture
 The `academictorrents` module only has one "public" function, `.get`. This function checks for the torrent data on the filesystem. If it is not present, then it initiates a `Client` to download the data for us.
 
 `Client` is our main thread, it manages the lifecycle of our other threads including `Tracker`, `PeerManager`, `PieceManager`, and many `WebSeedManager` threads. The `Client` thread uses the `PieceManager` class (not thread) to keep track of all the pieces of data. The main thread makes socket requests to `Peer`s, and enqueues jobs to request data from `HttpPeer`s. Socket responses are handled by `PeerManager`, whereas a fleet of `WebSeedManagers` threads handles the `HttpPeer`s.

--- a/academictorrents/__init__.py
+++ b/academictorrents/__init__.py
@@ -1,2 +1,3 @@
 from .academictorrents import get, set_datastore
+from .cli import cli
 from .version import __version__

--- a/academictorrents/cli.py
+++ b/academictorrents/cli.py
@@ -1,0 +1,54 @@
+import sys
+import argparse
+
+from .academictorrents import get
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Academic Torrents simple command line tool"
+    )
+
+    parser.add_argument(
+        "hash",
+        type=str,
+        help="Hash of the torrent to download",
+    )
+
+    parser.add_argument(
+        "-o",
+        "--datastore",
+        type=str,
+        default=".",
+        help="Location where to place the files",
+    )
+
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        default=False,
+        action="store_true",
+        help="Show logs",
+    )
+
+    args = parser.parse_args()
+
+    get(
+        args.hash,
+        datastore=args.datastore,
+        showlogs=args.verbose,
+    )
+
+    print("Exiting...")
+
+
+def cli():
+    """Entry point for the command line tool."""
+    try:
+        main()
+    except KeyboardInterrupt:
+        print("\nExited on keyboard interrupt.")
+
+
+if __name__ == "__main__":
+    cli()

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,3 @@ PyPubSub == 3.3.0
 requests >= 2.19.0
 pytest == 3.2.5
 future == 0.16.0
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ PyPubSub == 3.3.0
 requests >= 2.19.0
 pytest == 3.2.5
 future == 0.16.0
+numpy
+tqdm

--- a/setup.py
+++ b/setup.py
@@ -1,23 +1,23 @@
 from setuptools import setup, find_packages
-exec(open('academictorrents/version.py').read())
 
-with open('README.md') as f:
+exec(open("academictorrents/version.py").read())
+
+with open("README.md") as f:
     readme = f.read()
 
-with open('LICENSE') as f:
+with open("LICENSE") as f:
     license = f.read()
 
 setup(
-    name='academictorrents',
+    name="academictorrents",
     version=__version__,
-    description='Academic Torrents Python API',
-    author='Martin Weiss, Alexis Gallepe, Jonathan Nogueira',
-    author_email='contact@academictorrents.com',
-    data_files = [("", ["LICENSE"])],
-    url='https://github.com/AcademicTorrents/python-r-api',
+    description="Academic Torrents Python API",
+    author="Martin Weiss, Alexis Gallepe, Jonathan Nogueira",
+    author_email="contact@academictorrents.com",
+    data_files=[("", ["LICENSE"])],
+    url="https://github.com/AcademicTorrents/python-r-api",
     classifiers=(
-        "Programming Language :: Python :: 2.6"
-        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 2.6" "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.0",
         "Programming Language :: Python :: 3.1",
@@ -28,13 +28,16 @@ setup(
         "Programming Language :: Python :: 3.6",
     ),
     license=license,
-    packages=find_packages(exclude=('tests', 'docs')),
+    packages=find_packages(exclude=("tests", "docs")),
     install_requires=[
-        'bencode.py==2.0.0',
-        'bitstring==3.1.5',
-        'PyPubSub==3.3.0',
-        'requests>=2.19.0',
-        'future==0.16.0',
-        'tqdm',
+        "bencode.py==2.0.0",
+        "bitstring==3.1.5",
+        "PyPubSub==3.3.0",
+        "requests>=2.19.0",
+        "future==0.16.0",
+        "tqdm",
     ],
+    entry_points={
+        "console_scripts": ["atget = academictorrents:cli"],
+    },
 )

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,6 @@ setup(
         "tqdm",
     ],
     entry_points={
-        "console_scripts": ["atget = academictorrents:cli"],
+        "console_scripts": ["at-get = academictorrents:cli"],
     },
 )


### PR DESCRIPTION
This PR adds a simple command-line accessible directly from the user's path after installation. Here's how it looks:

![image](https://user-images.githubusercontent.com/32133147/116793722-60284400-aa96-11eb-9fad-2c579c32e488.png)

I just added an entry point in setup.py with a script similar to the example mentioned at https://github.com/academictorrents/at-python/issues/33.

A few points about this PR:
- I called the command `atget`, let me know if you would prefer another name
- I'm not sure what the URL and timestamp parameters from `academictorrents.get` do, but if you provide a bit of context/doc I would be happy to extend the command-line with more options. We can also split the command in various subcommands (e.g. `at get ewr576dsuf`, `at open file.torrent`, maybe even `at search mnist`, etc.).
- Once you're happy with this I can update the Readme and the doc to show how to use it

Other comments, to be addressed in different PRs/issues maybe:
- Some requirements are missing for the tests (tqdm, numpy)
- There is a weird delay between the moment where the download is complete and the time where the program actually exits. See https://github.com/academictorrents/at-python/issues/35
- The tests are failing:
![image](https://user-images.githubusercontent.com/32133147/116793909-9b774280-aa97-11eb-894b-8ab757c7945d.png)

