### PR TITLE
Support for Windows/Bug fixes for py3.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ pip install -r requirements.txt
 or more direct:
 
 ```
-python -m pip install git+https://github.com/ozendelait/at-python.git
+python -m pip install git+https://github.com/AcademicTorrents/at-python.git
 ```
 
 Done!

--- a/README.md
+++ b/README.md
@@ -75,6 +75,13 @@ git clone https://github.com/AcademicTorrents/at-python.git
 cd at-python
 pip install -r requirements.txt
 ```
+
+or more direct:
+
+```
+python -m pip install git+https://github.com/ozendelait/at-python.git
+```
+
 Done!
 
 ### Testing

--- a/academictorrents/Torrent.py
+++ b/academictorrents/Torrent.py
@@ -3,6 +3,7 @@ import bencode
 import logging
 import os
 import requests
+import tempfile
 from . import utils
 try:
     from urllib.parse import urlparse, urlencode
@@ -22,7 +23,7 @@ class Torrent(object):
         if not os.path.isdir(self.datastore):
             os.makedirs(self.datastore)
         try:
-            contents = open("/tmp/" + hash + '.torrent', 'rb').read()
+            contents = open(tempfile.gettempdir()+"/" + hash + '.torrent', 'rb').read()
         except Exception:
             contents = self.get_from_file()
             if not contents:
@@ -89,7 +90,7 @@ class Torrent(object):
         return urls
 
     def get_from_file(self):
-        torrent_path = os.path.join("/tmp/", self.hash + '.torrent')
+        torrent_path = os.path.join(tempfile.gettempdir()+"/", self.hash + '.torrent')
         try:
             return open(torrent_path, 'rb').read()
         except Exception:
@@ -99,7 +100,7 @@ class Torrent(object):
     def get_from_url(self):
         contents = None
         url = "http://academictorrents.com/download/" + self.hash
-        torrent_path = os.path.join("/tmp/", self.hash + '.torrent')
+        torrent_path = os.path.join(tempfile.gettempdir()+"/", self.hash + '.torrent')
         response = urlopen(url, timeout=5).read()
         open(torrent_path, 'wb').write(response)
         try:

--- a/academictorrents/Tracker.py
+++ b/academictorrents/Tracker.py
@@ -35,8 +35,8 @@ class Tracker(Thread):
         self.new_peers_queue = new_peers_queue
         self.stop_requested = False
         self.downloaded = downloaded
-        self.last_message_time = int(datetime.datetime.now().strftime("%s"))
-        self.last_update_time = int(datetime.datetime.now().strftime("%s"))
+        self.last_message_time = int(datetime.datetime.timestamp(datetime.datetime.now()))
+        self.last_update_time = int(datetime.datetime.timestamp(datetime.datetime.now()))
 
     def request_stop(self):
         self.stop_requested = True
@@ -51,7 +51,7 @@ class Tracker(Thread):
     def getPeersFromTrackers(self):
         if utils.timestamp_is_within_10_seconds(self.last_update_time):
             return
-        self.last_update_time = int(datetime.datetime.now().strftime("%s"))
+        self.last_update_time = int(datetime.datetime.timestamp(datetime.datetime.now()))
 
         for tracker in self.torrent.trackers:
             if tracker[0] == '':
@@ -118,7 +118,7 @@ class Tracker(Thread):
     def downloading_message(self):
         if utils.timestamp_is_within_10_seconds(self.last_message_time):
             return
-        self.last_message_time = int(datetime.datetime.now().strftime("%s"))
+        self.last_message_time = int(datetime.datetime.timestamp(datetime.datetime.now()))
         resp = requests.models.Response()
         if self.downloaded == 0:
             return True

--- a/academictorrents/utils.py
+++ b/academictorrents/utils.py
@@ -50,7 +50,7 @@ def write_timestamp(at_hash):
         f.close()
     except Exception:
         timestamps = {}
-    timestamps[at_hash] = int(datetime.datetime.now().strftime("%s"))
+    timestamps[at_hash] = int(datetime.datetime.timestamp(datetime.datetime.now()))
     f = open(filename, 'w')
     json.dump(timestamps, f)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -49,15 +49,15 @@ class UtilsTestSuite(unittest.TestCase):
         self.assertTrue(isinstance(timestamp, int))
 
     def test_check_timestamp_now(self):
-        ret = utils.timestamp_is_within_30_days(int(datetime.datetime.now().strftime("%s")))
+        ret = utils.timestamp_is_within_30_days(int(datetime.datetime.timestamp(datetime.datetime.now())))
         self.assertTrue(ret)
 
     def test_check_timestamp_two_weeks(self):
-        ret = utils.timestamp_is_within_30_days(int(datetime.datetime.now().strftime("%s")) - 86400 * 14)
+        ret = utils.timestamp_is_within_30_days(int(datetime.datetime.timestamp(datetime.datetime.now())) - 86400 * 14)
         self.assertTrue(ret)
 
     def test_check_timestamp_2_months(self):
-        ret = utils.timestamp_is_within_30_days(int(datetime.datetime.now().strftime("%s")) - 86400 * 60)
+        ret = utils.timestamp_is_within_30_days(int(datetime.datetime.timestamp(datetime.datetime.now())) - 86400 * 60)
         self.assertFalse(ret)
 
     def test_filename_checker(self):


### PR DESCRIPTION
-fixed "%s" format string (this is invalid, maybe it is supported as a special shortcut on some platforms)
-fixed absolute path "/tmp" which does not exists under Windows